### PR TITLE
Splitted view and display template, added core chooser.

### DIFF
--- a/Zikula/Module/ExtensionLibraryModule/Controller/UserController.php
+++ b/Zikula/Module/ExtensionLibraryModule/Controller/UserController.php
@@ -15,8 +15,13 @@ namespace Zikula\Module\ExtensionLibraryModule\Controller;
 
 use SecurityUtil;
 use ModUtil;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\Security\Core\Exception\AccessDeniedException;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route; // used in annotations - do not remove
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\ParamConverter; // used in annotations - do not remove
+use Zikula\Module\ExtensionLibraryModule\Entity\ExtensionEntity;
+use Zikula\Module\ExtensionLibraryModule\Util;
 use Zikula\Module\UsersModule\Constant as UsersConstant;
 
 /**
@@ -24,23 +29,86 @@ use Zikula\Module\UsersModule\Constant as UsersConstant;
  */
 class UserController extends \Zikula_AbstractController
 {
+    private function checkChosenCore()
+    {
+        if (!Util::getChosenCore()) {
+            $this->redirect(ModUtil::url('ZikulaExtensionLibraryModule', 'user', 'chooseCore'));
+        }
+    }
+
     /**
      * @Route("")
      * The default entry point.
      *
-     * @return string
+     * @return Response
+     * @throws AccessDeniedException
      */
     public function indexAction()
     {
-        // Security check
         if (!SecurityUtil::checkPermission($this->name.'::', '::', ACCESS_READ)) {
             throw new AccessDeniedException();
         }
-        $extensions = $this->entityManager->getRepository('ZikulaExtensionLibraryModule:ExtensionEntity')->findAll();
+        $this->checkChosenCore();
+
+        $extensions = $this->entityManager->getRepository('ZikulaExtensionLibraryModule:ExtensionEntity')->findAllMatchingCoreFilter();
         $this->view->assign('extensions', $extensions);
         $this->view->assign('gravatarDefaultPath', $this->request->getUriForPath('/'.UsersConstant::DEFAULT_AVATAR_IMAGE_PATH.'/'.UsersConstant::DEFAULT_GRAVATAR_IMAGE));
 
         return $this->response($this->view->fetch('User/view.tpl'));
     }
 
+    /**
+     * @Route("/display/{id}")
+     * @ParamConverter("extension", class="ZikulaExtensionLibraryModule:ExtensionEntity")
+     *
+     * Displays the detail page for an extension.
+     *
+     * @param int $id The extension id.
+     *
+     * @return Response
+     * @throws AccessDeniedException
+     */
+    public function display(ExtensionEntity $extension)
+    {
+        if (!SecurityUtil::checkPermission($this->name.'::', '::', ACCESS_READ)) {
+            throw new AccessDeniedException();
+        }
+        $this->checkChosenCore();
+
+        $this->view->assign('extension', $extension);
+        $this->view->assign('gravatarDefaultPath', $this->request->getUriForPath('/'.UsersConstant::DEFAULT_AVATAR_IMAGE_PATH.'/'.UsersConstant::DEFAULT_GRAVATAR_IMAGE));
+
+        return $this->response($this->view->fetch('User/display.tpl'));
+    }
+
+    /**
+     * @Route("/choose-your-core/{version}")
+     *
+     * @return Response
+     * @throws AccessDeniedException
+     */
+    public function chooseCore($version = null)
+    {
+        if (!SecurityUtil::checkPermission($this->name.'::', '::', ACCESS_READ)) {
+            throw new AccessDeniedException();
+        }
+
+        // @todo Fetch from GitHub.
+        $coreVersions = array(
+            'outdated'  => array('1.3.5' => 'foo', '1.3.4' => 'foo', '1.3.3' => 'foo', '1.3.2' => 'foo', '1.3.1' => 'foo', '1.3.0' => 'foo'),
+            'supported' => array('1.3.6' => 'foo'),
+            'dev'       => array('1.4.0' => 'foo'),
+        );
+
+        if (isset($version)) {
+            if (!($version === 'no-filter' || array_key_exists($version, $coreVersions['outdated']) || array_key_exists($version, $coreVersions['supported']) || array_key_exists($version, $coreVersions['dev']))) {
+                throw new NotFoundHttpException();
+            }
+            Util::setChosenCore($version);
+            $this->redirect(ModUtil::url('ZikulaExtensionLibraryModule', 'user', 'index'));
+        }
+
+        $this->view->assign('coreVersions', array_reverse($coreVersions, true));
+        return $this->response($this->view->fetch('User/chooseCore.tpl'));
+    }
 }

--- a/Zikula/Module/ExtensionLibraryModule/Entity/ExtensionEntity.php
+++ b/Zikula/Module/ExtensionLibraryModule/Entity/ExtensionEntity.php
@@ -21,7 +21,7 @@ use Gedmo\Mapping\Annotation as Gedmo;
 /**
  * Extension entity class
  *
- * @ORM\Entity
+ * @ORM\Entity(repositoryClass="Zikula\Module\ExtensionLibraryModule\Entity\Repository\ExtensionRepository")
  * @ORM\Table(name="el_extension")
  */
 class ExtensionEntity extends EntityAccess
@@ -193,7 +193,7 @@ class ExtensionEntity extends EntityAccess
     }
 
     /**
-     * @return ArrayCollection
+     * @return ArrayCollection|ExtensionVersionEntity[]
      */
     public function getVersions()
     {
@@ -319,6 +319,9 @@ class ExtensionEntity extends EntityAccess
      */
     public function getIcon()
     {
+        if (empty($this->icon)) {
+            return 'modules/Zikula/Module/ExtensionLibraryModule/Resources/public/images/zikula.png';
+        }
         return $this->icon;
     }
 

--- a/Zikula/Module/ExtensionLibraryModule/Entity/Repository/ExtensionRepository.php
+++ b/Zikula/Module/ExtensionLibraryModule/Entity/Repository/ExtensionRepository.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * Copyright Zikula Foundation 2014 - Zikula Application Framework
+ *
+ * This work is contributed to the Zikula Foundation under one or more
+ * Contributor Agreements and licensed to You under the following license:
+ *
+ * @license MIT
+ *
+ * Please see the NOTICE file distributed with this source code for further
+ * information regarding copyright and licensing.
+ */
+
+namespace Zikula\Module\ExtensionLibraryModule\Entity\Repository;
+
+use Doctrine\ORM\EntityRepository;
+use Zikula\Module\ExtensionLibraryModule\Entity\ExtensionEntity;
+use Zikula\Module\ExtensionLibraryModule\Util;
+
+/**
+ * Extension repository class.
+ */
+class ExtensionRepository extends EntityRepository
+{
+    public function findAllMatchingCoreFilter($version = null)
+    {
+        if (!isset($version)) {
+            $version = Util::getChosenCore();
+        }
+        if ($version === 'no-filter' || $version === false || 1) {
+            // @todo Filter extensions not matching the currently selected filter.
+            return $this->findAll();
+        }
+    }
+}

--- a/Zikula/Module/ExtensionLibraryModule/Resources/public/css/style.css
+++ b/Zikula/Module/ExtensionLibraryModule/Resources/public/css/style.css
@@ -1,0 +1,10 @@
+.iconStack {
+    position: relative;
+}
+.iconStack .vendorIcon {
+    position: absolute;
+    bottom: 0;
+    right: 0;
+    width: 30px;
+    height: 30px;
+}

--- a/Zikula/Module/ExtensionLibraryModule/Resources/views/User/chooseCore.tpl
+++ b/Zikula/Module/ExtensionLibraryModule/Resources/views/User/chooseCore.tpl
@@ -1,0 +1,44 @@
+{include file='User/header.tpl'}
+<h2>{gt text='Choose the core to browse extensions for'}</h2>
+<h3>{gt text='Show extensions for all core versions'}</h3>
+<div class="row">
+<div class="col-sm-2 text-center">
+    <a class="btn btn-default" href="el/choose-your-core/no-filter">
+        {img src='zikula.png'}
+        <strong>{gt text='All versions'}</strong>
+    </a>
+</div>
+</div>
+<h3>{gt text='Current version'}</h3>
+<div class="row">
+    {foreach from=$coreVersions.supported item='versionData' key='version'}
+        <div class="col-sm-2 text-center">
+            <a class="btn btn-success" href="el/choose-your-core/{$version}">
+                {img src='zikula.png'}
+                <strong>{$version}</strong>
+            </a>
+        </div>
+    {/foreach}
+</div>
+<h3>{gt text='Outdated versions'}</h3>
+<div class="row">
+    {foreach from=$coreVersions.outdated item='versionData' key='version'}
+    <div class="col-sm-2 text-center">
+        <a class="btn btn-info" href="el/choose-your-core/{$version}">
+            {img src='zikula.png'}
+            <strong>{$version}</strong>
+        </a>
+    </div>
+    {/foreach}
+</div>
+<h3>{gt text='Experimental development versions'}</h3>
+<div class="row">
+    {foreach from=$coreVersions.dev item='versionData' key='version'}
+    <div class="col-sm-2 text-center">
+        <a class="btn btn-default" href="el/choose-your-core/{$version}">
+            {img src='zikula.png'}
+            <strong class="text-muted">{$version}</strong>
+        </a>
+    </div>
+    {/foreach}
+</div>

--- a/Zikula/Module/ExtensionLibraryModule/Resources/views/User/display.tpl
+++ b/Zikula/Module/ExtensionLibraryModule/Resources/views/User/display.tpl
@@ -1,0 +1,56 @@
+{capture assign='title'}
+    {$extension.title|safetext}&nbsp;&nbsp;<small>{$extension.type}</small>
+{/capture}
+
+{include file='User/header.tpl' title=$title icon=$extension.icon}
+<div  class="pull-right">
+    <h3>{$extension.vendor.title|safetext}</h3>
+    <div style="min-height: 80px;">
+        {if isset($extension.vendor.ownerEmail)}
+        <img src="http://www.gravatar.com/avatar/{$extension.vendor.ownerEmail|md5}?d=identicon" alt="" class="img-thumbnail pull-left">
+        {/if}
+        <ul class="list-unstyled" style="padding-left: 100px">
+            <li>{$extension.vendor.ownerName|default:''}</li>
+            <li>{$extension.vendor.ownerEmail|default:''}</li>
+            <li><i class="fa fa-external-link"></i> <a href="{$extension.vendor.ownerUrl|default:''}">{gt text="Vendor Website"}</a></li>
+        </ul>
+    </div>
+</div>
+<div>
+    <ul class="list-unstyled">
+        <li><i class="fa fa-external-link"></i> <a href="{$extension.url|default:''}">{gt text="Extension Website"}</a></li>
+    </ul>
+</div>
+<div class="clear"></div>
+<br />
+
+<div class="panel-group" id="accordion">
+{foreach from=$extension.versions item="version" name="versionLoop"}
+    <div class="panel panel-default">
+        <div class="panel-heading">
+            <em class="pull-right">
+                <span class="label label-info tooltips" title="{gt text='Zikula Core version compatibility'}">{$version.compatibility}</span>&nbsp;
+                Released: {$version.created->format('j M Y')}
+            </em>
+            <h4 class="panel-title">
+                <a data-toggle="collapse" data-parent="#accordion" href="#version-{$version.id}">
+                    <strong>Version: {$version.semver|safetext}</strong>
+                </a>
+            </h4>
+        </div>
+        <div id="version-{$version.id}" class="panel-collapse collapse{if $smarty.foreach.versionLoop.first} in{/if}">
+            <div class="panel-body">
+                <ul>
+                    <li>Description: {$version.description|safetext}</li>
+                </ul>
+                {if isset($version.urls.download)}
+                    <a type="button" class="btn btn-success" href="{$version.urls.download}">Download</a>
+                {else}
+                    <a type="button" class="btn btn-success" href="{$version.urls.zipball_url}">Download Zipball</a>
+                    <a type="button" class="btn btn-success" href="{$version.urls.tarball_url}">Download Tarball</a>
+                {/if}
+            </div>
+        </div>
+    </div>
+{/foreach}
+</div>

--- a/Zikula/Module/ExtensionLibraryModule/Resources/views/User/header.tpl
+++ b/Zikula/Module/ExtensionLibraryModule/Resources/views/User/header.tpl
@@ -1,0 +1,18 @@
+{if !isset($icon)}
+    <img src="{modgetimage}" alt="" class="pull-left" />
+{else}
+    <img src="{$icon}" alt="" class="pull-left" />
+{/if}
+{zikulaextensionlibrarymodulecorefilter assign='coreVersion'}
+{if !empty($coreVersion)}
+    <p class="pull-right">
+        {if $coreVersion !== 'no-filter'}
+            {gt text='Only showing extensions compatible with'}&nbsp;<span class="label label-info">Zikula Core {$coreVersion}</span>
+        {else}
+            {gt text='Showing all extensions'}
+        {/if}
+        - <a href="{modurl modname='ZikulaExtensionLibraryModule' type='user' func='chooseCore'}">{gt text='Change'}</a>
+    </p>
+{/if}
+<h1><i>{modgetinfo info='displayname'}</i>{if isset($title)} &ndash; {$title}{/if}</h1>
+<hr />

--- a/Zikula/Module/ExtensionLibraryModule/Resources/views/User/view.tpl
+++ b/Zikula/Module/ExtensionLibraryModule/Resources/views/User/view.tpl
@@ -1,49 +1,29 @@
-{foreach from=$extensions item="extension"}
-    <h2>{$extension.vendor.title|safetext}</h2>
-    <div style="min-height: 80px;">
-        {if isset($extension.vendor.ownerEmail)}
-            <img src="http://www.gravatar.com/avatar/{$extension.vendor.ownerEmail|md5}?d=identicon" alt="" class="img-thumbnail pull-left">
+{include file='User/header.tpl'}
+<div class="row">
+    {foreach from=$extensions item="extension" name='loop'}
+        {if ($smarty.foreach.loop.iteration - 1) % 3 == 0 && $smarty.foreach.loop.iteration != 1}
+        </div>
+        <hr />
+        <div class="row">
         {/if}
-        <ul class="list-unstyled" style="padding-left: 100px">
-            <li>{$extension.vendor.ownerName|default:''}</li>
-            <li>{$extension.vendor.ownerEmail|default:''}</li>
-            <li><i class="fa fa-external-link"></i> <a href="{$extension.vendor.ownerUrl|default:''}">{gt text="Vendor Website"}</a></li>
-        </ul>
-    </div>
-    <h3>{$extension.title|safetext}&nbsp;&nbsp;<small>{$extension.type}</small></h3>
-    <div>
-        <ul class="list-unstyled">
-            <li><i class="fa fa-external-link"></i> <a href="{$extension.url|default:''}">{gt text="Extension Website"}</a></li>
-        </ul>
-    </div>
-    <div class="panel-group" id="accordion">
-    {foreach from=$extension.versions item="version" name="versionLoop"}
-        <div class="panel panel-default">
-            <div class="panel-heading">
-                <em class="pull-right">
-                    <span class="label label-info tooltips" title="{gt text='Zikula Core version compatibility'}">{$version.compatibility}</span>&nbsp;
-                    Released: {$version.created->format('j M Y')}
-                </em>
-                <h4 class="panel-title">
-                    <a data-toggle="collapse" data-parent="#accordion" href="#version-{$version.id}">
-                        <strong>Version: {$version.semver|safetext}</strong>
-                    </a>
-                </h4>
-            </div>
-            <div id="version-{$version.id}" class="panel-collapse collapse{if $smarty.foreach.versionLoop.first} in{/if}">
-                <div class="panel-body">
-                    <ul>
-                        <li>Description: {$version.description|safetext}</li>
+        <div class="col-sm-4">
+            <div class="media">
+                <a class="pull-left" href="{modurl modname='ZikulaExtensionLibraryModule' type='user' func='display' id=$extension->getId()}">
+                    <div class="iconStack">
+                        <img class="media-object img-thumbnail" src="{$extension->getIcon()}" alt="" width="90" height="90" />
+                        {if isset($extension.vendor.ownerEmail)}
+                            <img class="img-thumbnail vendorIcon" src="http://www.gravatar.com/avatar/{$extension.vendor.ownerEmail|md5}?d=identicon" alt="">
+                        {/if}
+                    </div>
+                </a>
+                <div class="media-body">
+                    <h4 class="media-heading"><a href="{modurl modname='ZikulaExtensionLibraryModule' type='user' func='display' id=$extension->getId()}">{$extension.title|safetext}&nbsp;&nbsp;<small>{$extension.type}</small></a></h4>
+                    <ul class="list-unstyled">
+                        <li>{$extension.vendor.ownerName|default:''}</li>
+                        <li><i class="fa fa-external-link"></i> <a href="{$extension.vendor.ownerUrl|default:''}">{gt text="Vendor Website"}</a></li>
                     </ul>
-                    {if isset($version.urls.download)}
-                        <a type="button" class="btn btn-success" href="{$version.urls.download}">Download</a>
-                    {else}
-                        <a type="button" class="btn btn-success" href="{$version.urls.zipball_url}">Download Zipball</a>
-                        <a type="button" class="btn btn-success" href="{$version.urls.tarball_url}">Download Tarball</a>
-                    {/if}
                 </div>
             </div>
         </div>
     {/foreach}
-    </div>
-{/foreach}
+</div>

--- a/Zikula/Module/ExtensionLibraryModule/Resources/views/plugins/function.zikulaextensionlibrarymodulecorefilter.php
+++ b/Zikula/Module/ExtensionLibraryModule/Resources/views/plugins/function.zikulaextensionlibrarymodulecorefilter.php
@@ -1,0 +1,12 @@
+<?php
+
+function smarty_function_zikulaextensionlibrarymodulecorefilter($params, &$view)
+{
+    $version = \Zikula\Module\ExtensionLibraryModule\Util::getChosenCore();
+
+    if (isset($params['assign']) && !empty($params['assign'])) {
+        $view->assign($params['assign'], $version);
+    } else {
+        return $version;
+    }
+}

--- a/Zikula/Module/ExtensionLibraryModule/Util.php
+++ b/Zikula/Module/ExtensionLibraryModule/Util.php
@@ -31,4 +31,13 @@ class Util {
         fclose($fd);
     }
 
+    public static function setChosenCore($version)
+    {
+        \CookieUtil::setCookie('zikulaextensionslibrarymodule_chosenCore', $version, time() + 60*60*24, '/');
+    }
+
+    public static function getChosenCore()
+    {
+        return \CookieUtil::getCookie('zikulaextensionslibrarymodule_chosenCore');
+    }
 } 


### PR DESCRIPTION
Todos for further PRs:
- Fetch core versions from GitHub
- Filter by chosen core in `ExtensionRepository::findAllMatchingCoreFilter()` (currently ignoring the filter).
